### PR TITLE
Tool informations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,9 +146,9 @@
             <version>2.6.5</version>
         </dependency>
         <dependency>
-        	<groupId>org.openrdf.sesame</groupId>
-        	<artifactId>sesame-queryrender</artifactId>
-        	<version>2.7.12</version>
+            <groupId>org.openrdf.sesame</groupId>
+            <artifactId>sesame-queryrender</artifactId>
+            <version>2.7.12</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/general/Main.java
+++ b/src/main/java/general/Main.java
@@ -90,7 +90,7 @@ public final class Main
    */
   public static void main(String[] args) throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException
   {
-    //args = new String[] {"-olt", "-file test/test/test/QueryCntSept", "-n5"};
+    args = new String[] {"-olt", "-file test/test/test/QueryCntSept", "-n5"};
 
     Options options = new Options();
     options.addOption("l", "logging", false, "enables file logging");

--- a/src/main/java/general/Main.java
+++ b/src/main/java/general/Main.java
@@ -19,6 +19,19 @@ package general;
  * #L%
  */
 
+import input.InputHandlerParquet;
+import input.InputHandlerTSV;
+import logging.LoggingHandler;
+import org.apache.commons.cli.*;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.openrdf.query.parser.ParsedQuery;
+import org.openrdf.queryrender.sparql.SPARQLQueryRenderer;
+import query.JenaQueryHandler;
+import query.OpenRDFQueryHandler;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -28,37 +41,10 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
-import input.InputHandlerParquet;
-import input.InputHandlerTSV;
-import logging.LoggingHandler;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.UnrecognizedOptionException;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.apache.spark.SparkConf;
-import org.apache.spark.api.java.JavaSparkContext;
-import org.openrdf.query.algebra.TupleExpr;
-import org.openrdf.query.parser.ParsedQuery;
-import org.openrdf.queryrender.sparql.SPARQLQueryRenderer;
-
-import query.JenaQueryHandler;
-import query.OpenRDFQueryHandler;
-
-
-
 
 
 /**
@@ -90,7 +76,7 @@ public final class Main
    */
   public static void main(String[] args) throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException
   {
-    args = new String[] {"-olt", "-file test/test/test/QueryCntSept", "-n5"};
+    args = new String[] {"-olt", "-file test/test/test/QueryCntSept", "-n1"};
 
     Options options = new Options();
     options.addOption("l", "logging", false, "enables file logging");
@@ -191,8 +177,7 @@ public final class Main
         bw.write(renderer.render(queryTypes.get(i)));
       } catch (IOException e) {
         logger.error("Could not write the query type " + i + ".", e);
-      }
-      catch (Exception e) {
+      } catch (Exception e) {
         logger.error("Error while rendering query type " + i + ".", e);
       }
     }

--- a/src/main/java/general/Main.java
+++ b/src/main/java/general/Main.java
@@ -76,7 +76,7 @@ public final class Main
    */
   public static void main(String[] args) throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException
   {
-    args = new String[] {"-olt", "-file test/test/test/QueryCntSept", "-n1"};
+    //args = new String[] {"-olt", "-file test/test/test/QueryCntSept", "-n1"};
 
     Options options = new Options();
     options.addOption("l", "logging", false, "enables file logging");

--- a/src/main/java/general/ParseOneMonthWorker.java
+++ b/src/main/java/general/ParseOneMonthWorker.java
@@ -23,7 +23,7 @@ public class ParseOneMonthWorker implements Runnable
   private String inputFilePrefix;
   private InputHandler inputHandler;
   private String queryParserName;
-  private QueryHandler queryHandler;
+  private Class queryHandlerClass;
   private int day;
 
   public ParseOneMonthWorker(String inputFile, String inputFilePrefix, Class inputHandlerClass, String queryParserName, Class queryHandlerClass, int day) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException
@@ -32,7 +32,7 @@ public class ParseOneMonthWorker implements Runnable
     this.inputFilePrefix = inputFilePrefix;
     this.inputHandler = (InputHandler) inputHandlerClass.getConstructor().newInstance();
     this.queryParserName = queryParserName;
-    this.queryHandler = (QueryHandler) queryHandlerClass.getConstructor().newInstance();
+    this.queryHandlerClass = queryHandlerClass;
     this.day = day;
   }
 
@@ -48,7 +48,7 @@ public class ParseOneMonthWorker implements Runnable
 
       logger.info("Start processing " + inputFile);
       try {
-        OutputHandlerTSV outputHandler = new OutputHandlerTSV(outputFile, queryHandler);
+        OutputHandlerTSV outputHandler = new OutputHandlerTSV(outputFile, queryHandlerClass);
         //try {
         inputHandler.parseTo(outputHandler);
         logger.info("Done processing " + inputFile + " to " + outputFile + ".");

--- a/src/main/java/output/OutputHandler.java
+++ b/src/main/java/output/OutputHandler.java
@@ -1,6 +1,7 @@
 package output;
 
 import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
 
 /**
  * @author adrian

--- a/src/main/java/output/OutputHandlerTSV.java
+++ b/src/main/java/output/OutputHandlerTSV.java
@@ -64,6 +64,9 @@ public class OutputHandlerTSV extends OutputHandler
     header.add("#VariableCountPattern");
     header.add("#TripleCountWithService");
     header.add("#TripleCountNoService");
+    header.add("#ToolName");
+    header.add("#ToolVersion");
+    header.add("#ToolCommentInfo");
     header.add("#QueryType");
     header.add("#uri_path");
     header.add("#user_agent");
@@ -120,6 +123,9 @@ public class OutputHandlerTSV extends OutputHandler
     line.add(queryHandler.getVariableCountHead());
     line.add(queryHandler.getVariableCountPattern());
     line.add(queryHandler.getTripleCountWithService());
+    line.add(-1);
+    line.add(-1);
+    line.add(-1);
     line.add(-1);
     line.add(queryHandler.getQueryType());
     for (int i = 1; i < row.length; i++) {

--- a/src/main/java/output/OutputHandlerTSV.java
+++ b/src/main/java/output/OutputHandlerTSV.java
@@ -7,6 +7,7 @@ import query.QueryHandler;
 
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,10 +24,12 @@ public class OutputHandlerTSV extends OutputHandler
    * Define a static logger variable.
    */
   private static Logger logger = Logger.getLogger(OutputHandlerTSV.class);
+
   /**
-   * The handler used to process the rows to output.
+   * the class of wich a queryHandlerObject should be created
    */
-  private QueryHandler queryHandler;
+  private final Class queryHandlerClass;
+
   /**
    * A writer created at object creation to be used in line-by-line writing.
    */
@@ -39,15 +42,14 @@ public class OutputHandlerTSV extends OutputHandler
   /**
    * Creates the file specified in the constructor and writes the header.
    *
-   * @param queryHandlerToUse The handler used to analyze the query string that will be written
    * @param fileToWrite       location of the file to write the received values to
+   * @param queryHandlerClass handler class used to analyze the query string that will be written
    * @throws FileNotFoundException if the file exists but is a directory
    *                               rather than a regular file, does not exist but cannot be created,
    *                               or cannot be opened for any other reason
    */
-  public OutputHandlerTSV(String fileToWrite, QueryHandler queryHandlerToUse) throws FileNotFoundException
+  public OutputHandlerTSV(String fileToWrite, Class queryHandlerClass) throws FileNotFoundException
   {
-    this.queryHandler = queryHandlerToUse;
     this.file = fileToWrite;
     FileOutputStream outputWriter = new FileOutputStream(fileToWrite + ".tsv");
     writer = new TsvWriter(outputWriter, new TsvWriterSettings());
@@ -55,6 +57,8 @@ public class OutputHandlerTSV extends OutputHandler
       hourly_user[i] = 0L;
       hourly_spider[i] = 0L;
     }
+
+    this.queryHandlerClass = queryHandlerClass;
 
     List<String> header = new ArrayList<String>();
     header.add("#Valid");
@@ -109,6 +113,18 @@ public class OutputHandlerTSV extends OutputHandler
   @Override
   public final void writeLine(String queryToAnalyze, Integer validityStatus, Object[] row, long currentLine, String currentFile)
   {
+    QueryHandler queryHandler = null;
+    try {
+      queryHandler = (QueryHandler) queryHandlerClass.getConstructor().newInstance();
+    } catch (InstantiationException e) {
+      logger.error("Failed to create query handler object" + e);
+    } catch (IllegalAccessException e) {
+      logger.error("Failed to create query handler object" + e);
+    } catch (InvocationTargetException e) {
+      logger.error("Failed to create query handler object" + e);
+    } catch (NoSuchMethodException e) {
+      logger.error("Failed to create query handler object" + e);
+    }
     queryHandler.setValidityStatus(validityStatus);
     queryHandler.setQueryString(queryToAnalyze);
     queryHandler.setCurrentLine(currentLine);
@@ -124,9 +140,9 @@ public class OutputHandlerTSV extends OutputHandler
     line.add(queryHandler.getVariableCountPattern());
     line.add(queryHandler.getTripleCountWithService());
     line.add(-1);
-    line.add(-1);
-    line.add(-1);
-    line.add(-1);
+    line.add(queryHandler.getToolName());
+    line.add(queryHandler.getToolVersion());
+    line.add(queryHandler.getToolCommentInfo());
     line.add(queryHandler.getQueryType());
     for (int i = 1; i < row.length; i++) {
       line.add(row[i]);

--- a/src/main/java/query/OpenRDFQueryHandler.java
+++ b/src/main/java/query/OpenRDFQueryHandler.java
@@ -1,25 +1,18 @@
 package query;
 
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-
 import general.Main;
-
 import org.openrdf.query.MalformedQueryException;
 import org.openrdf.query.algebra.StatementPattern;
 import org.openrdf.query.algebra.TupleExpr;
 import org.openrdf.query.algebra.Var;
-import org.openrdf.query.algebra.helpers.QueryModelVisitorBase;
 import org.openrdf.query.algebra.helpers.StatementPatternCollector;
 import org.openrdf.query.parser.ParsedQuery;
 import org.openrdf.query.parser.sparql.ast.ASTQueryContainer;
-import org.openrdf.query.parser.sparql.ast.ParseException;
-import org.openrdf.query.parser.sparql.ast.SyntaxTreeBuilder;
-import org.openrdf.query.parser.sparql.ast.TokenMgrError;
-import org.openrdf.query.parser.sparql.ast.VisitorException;
-import org.openrdf.queryrender.sparql.SPARQLQueryRenderer;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
 
 /**

--- a/src/main/java/query/QueryHandler.java
+++ b/src/main/java/query/QueryHandler.java
@@ -115,10 +115,9 @@ public abstract class QueryHandler
     //assuming that, if there is a tool comment at all, it is the first comment
     //in the query and that it start with a #TOOL: and that the tool name is then
     //everything until the end of that line
-    logger.info("newline");
-    System.out.println(queryStringToSet);
     if(queryStringToSet.startsWith("#TOOL:")) {
       this.setToolCommentInfo(queryStringToSet.substring(6, queryStringToSet.indexOf("\n")));
+      this.setToolName(this.getToolCommentInfo());
     }
 
     return;

--- a/src/main/java/query/QueryHandler.java
+++ b/src/main/java/query/QueryHandler.java
@@ -1,10 +1,10 @@
 package query;
 
+import org.apache.log4j.Logger;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
-
-import org.apache.log4j.Logger;
 
 /**
  * @author adrian
@@ -50,6 +50,27 @@ public abstract class QueryHandler
   private int lengthNoAddedPrefixes;
 
   /**
+   * the name of the tool which created the query
+   * 0 for user querys
+   * -1 for unknown tool
+   */
+  private String toolName = "0";
+
+  /**
+   * the version of the tool which created the query
+   * 0 for unknown
+   * -1 for unknown tool
+   */
+  private String toolVersion = "0";
+
+  /**
+   * the tool name from the query comment
+   * 0 if undefined
+   * -1 for unknown tool
+   */
+  private String toolCommentInfo = "0";
+
+  /**
    *
    */
   public QueryHandler()
@@ -59,7 +80,7 @@ public abstract class QueryHandler
   }
 
   /**
-   * Updated the handler to represent the string in queryString.
+   * Update the handler to represent the string in queryString.
    */
   public abstract void update();
 
@@ -90,6 +111,16 @@ public abstract class QueryHandler
       this.queryString = this.addMissingPrefixesToQuery(queryStringToSet);
       update();
     }
+
+    //assuming that, if there is a tool comment at all, it is the first comment
+    //in the query and that it start with a #TOOL: and that the tool name is then
+    //everything until the end of that line
+    logger.info("newline");
+    System.out.println(queryStringToSet);
+    if(queryStringToSet.startsWith("#TOOL:")) {
+      this.setToolCommentInfo(queryStringToSet.substring(6, queryStringToSet.indexOf("\n")));
+    }
+
     return;
   }
 
@@ -206,7 +237,7 @@ public abstract class QueryHandler
    * @return Returns the query type as a number referencing a file containing the queryTypePattern.
    */
   public abstract Integer getQueryType();
-  
+
   /**
    * @return the line the query originated from
    */
@@ -242,5 +273,35 @@ public abstract class QueryHandler
   public int getLengthNoAddedPrefixes()
   {
     return lengthNoAddedPrefixes;
+  }
+
+  public String getToolName()
+  {
+    return toolName;
+  }
+
+  public void setToolName(String toolName)
+  {
+    this.toolName = toolName;
+  }
+
+  public String getToolVersion()
+  {
+    return toolVersion;
+  }
+
+  public void setToolVersion(String toolVersion)
+  {
+    this.toolVersion = toolVersion;
+  }
+
+  public String getToolCommentInfo()
+  {
+    return toolCommentInfo;
+  }
+
+  public void setToolCommentInfo(String toolCommentInfo)
+  {
+    this.toolCommentInfo = toolCommentInfo;
   }
 }

--- a/src/main/java/query/StandardizingSPARQLParser.java
+++ b/src/main/java/query/StandardizingSPARQLParser.java
@@ -1,12 +1,7 @@
 /**
- * 
+ *
  */
 package query;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import org.openrdf.model.impl.ValueFactoryImpl;
 import org.openrdf.query.Dataset;
@@ -17,48 +12,30 @@ import org.openrdf.query.parser.ParsedBooleanQuery;
 import org.openrdf.query.parser.ParsedGraphQuery;
 import org.openrdf.query.parser.ParsedQuery;
 import org.openrdf.query.parser.ParsedTupleQuery;
-import org.openrdf.query.parser.sparql.ASTVisitorBase;
-import org.openrdf.query.parser.sparql.BaseDeclProcessor;
-import org.openrdf.query.parser.sparql.BlankNodeVarProcessor;
-import org.openrdf.query.parser.sparql.DatasetDeclProcessor;
-import org.openrdf.query.parser.sparql.PrefixDeclProcessor;
-import org.openrdf.query.parser.sparql.SPARQLParser;
-import org.openrdf.query.parser.sparql.StringEscapesProcessor;
-import org.openrdf.query.parser.sparql.TupleExprBuilder;
-import org.openrdf.query.parser.sparql.WildcardProjectionProcessor;
-import org.openrdf.query.parser.sparql.ast.ASTAskQuery;
-import org.openrdf.query.parser.sparql.ast.ASTBind;
-import org.openrdf.query.parser.sparql.ast.ASTBindingValue;
-import org.openrdf.query.parser.sparql.ast.ASTConstructQuery;
-import org.openrdf.query.parser.sparql.ast.ASTDescribeQuery;
-import org.openrdf.query.parser.sparql.ast.ASTQName;
-import org.openrdf.query.parser.sparql.ast.ASTQuery;
-import org.openrdf.query.parser.sparql.ast.ASTQueryContainer;
-import org.openrdf.query.parser.sparql.ast.ASTSelectQuery;
-import org.openrdf.query.parser.sparql.ast.ASTString;
-import org.openrdf.query.parser.sparql.ast.ASTVar;
-import org.openrdf.query.parser.sparql.ast.Node;
-import org.openrdf.query.parser.sparql.ast.ParseException;
-import org.openrdf.query.parser.sparql.ast.SyntaxTreeBuilder;
-import org.openrdf.query.parser.sparql.ast.SyntaxTreeBuilderVisitor;
-import org.openrdf.query.parser.sparql.ast.TokenMgrError;
-import org.openrdf.query.parser.sparql.ast.VisitorException;
+import org.openrdf.query.parser.sparql.*;
+import org.openrdf.query.parser.sparql.ast.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author adrian
- *
  */
 public class StandardizingSPARQLParser extends SPARQLParser
 {
 
   /**
    * Moves BIND()-clauses to the top of the query.
+   *
    * @param queryToBeDebugged The query to be debugged
    */
   public final void debug(ASTQueryContainer queryToBeDebugged)
   {
     try {
-      queryToBeDebugged.jjtAccept(new ASTVisitorBase() {
+      queryToBeDebugged.jjtAccept(new ASTVisitorBase()
+      {
         public Object visit(ASTBind node, Object data) throws VisitorException
         {
           Node parent = node.jjtGetParent();
@@ -84,14 +61,14 @@ public class StandardizingSPARQLParser extends SPARQLParser
           return super.visit(node, data);
         }
       }, null);
-    }
-    catch (VisitorException e) {
+    } catch (VisitorException e) {
       e.printStackTrace();
     }
   }
 
   /**
    * Normalizes a query by replacing all variables with var1, var2 and so on.
+   *
    * @param queryContainer The query to be normalized
    * @throws MalformedQueryException if the query was malformed
    */
@@ -101,7 +78,8 @@ public class StandardizingSPARQLParser extends SPARQLParser
     final Map<String, Integer> strings = new HashMap<String, Integer>();
     final Map<String, Integer> qnames = new HashMap<String, Integer>();
     try {
-      queryContainer.jjtAccept(new ASTVisitorBase() {
+      queryContainer.jjtAccept(new ASTVisitorBase()
+      {
 
         public Object visit(ASTVar variable, Object data) throws VisitorException
         {
@@ -119,7 +97,7 @@ public class StandardizingSPARQLParser extends SPARQLParser
             strings.put(string.getValue(), strings.keySet().size() + 1);
           }
           string.setValue("string" + strings.get(string.getValue()));
-          return super.visit(string,  data);
+          return super.visit(string, data);
         }
 
         @Override
@@ -129,14 +107,12 @@ public class StandardizingSPARQLParser extends SPARQLParser
             qnames.put(qname.getValue(), qnames.keySet().size() + 1);
           }
           qname.setValue(qname.getValue().split(":")[0] + ":qname" + qnames.get(qname.getValue()));
-          return super.visit(qname,  data);
+          return super.visit(qname, data);
         }
       }, null);
-    }
-    catch (TokenMgrError e) {
+    } catch (TokenMgrError e) {
       throw new MalformedQueryException(e);
-    }
-    catch (VisitorException e) {
+    } catch (VisitorException e) {
       throw new MalformedQueryException(e);
     }
     return;
@@ -167,17 +143,13 @@ public class StandardizingSPARQLParser extends SPARQLParser
         ASTQuery queryNode = qc.getQuery();
         if (queryNode instanceof ASTSelectQuery) {
           query = new ParsedTupleQuery(queryString, tupleExpr);
-        }
-        else if (queryNode instanceof ASTConstructQuery) {
+        } else if (queryNode instanceof ASTConstructQuery) {
           query = new ParsedGraphQuery(queryString, tupleExpr, prefixes);
-        }
-        else if (queryNode instanceof ASTAskQuery) {
+        } else if (queryNode instanceof ASTAskQuery) {
           query = new ParsedBooleanQuery(queryString, tupleExpr);
-        }
-        else if (queryNode instanceof ASTDescribeQuery) {
+        } else if (queryNode instanceof ASTDescribeQuery) {
           query = new ParsedGraphQuery(queryString, tupleExpr, prefixes);
-        }
-        else {
+        } else {
           throw new RuntimeException(
               "Unexpected query type: " + queryNode.getClass());
         }
@@ -189,16 +161,13 @@ public class StandardizingSPARQLParser extends SPARQLParser
         }
 
         return query;
-      }
-      else {
+      } else {
         throw new IncompatibleOperationException(
             "supplied string is not a query operation");
       }
-    }
-    catch (TokenMgrError e) {
+    } catch (TokenMgrError e) {
       throw new MalformedQueryException(e.getMessage(), e);
-    }
-    catch (ParseException e) {
+    } catch (ParseException e) {
       throw new MalformedQueryException(e.getMessage(), e);
     }
   }
@@ -209,8 +178,7 @@ public class StandardizingSPARQLParser extends SPARQLParser
         new ValueFactoryImpl());
     try {
       return (TupleExpr) qc.jjtAccept(tupleExprBuilder, null);
-    }
-    catch (VisitorException e) {
+    } catch (VisitorException e) {
       throw new MalformedQueryException(e.getMessage(), e);
     }
   }


### PR DESCRIPTION
Three new TSV output columns: #ToolName, #ToolVersion and #ToolCommentInfo
By now only ToolCommentInfo get's set if the comment exists in the data, should be extended using queryTypes if a querType can be assigned surely to a tool.
- fixes a bug that QueryHandler objects weren't always being recreated, sometimes the data from a previous query was reused (especially for invalid queries)