### PR TITLE
FIX: AccessFrequencyMap and AccessFrequencyMap for queryTypes

### DIFF
--- a/src/main/java/accessfrequencymap/AccessFrequencyMap.java
+++ b/src/main/java/accessfrequencymap/AccessFrequencyMap.java
@@ -2,6 +2,7 @@ package accessfrequencymap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -88,7 +89,14 @@ public class AccessFrequencyMap<K, V> implements Map<K, V>
   @Override
   public Set<K> keySet()
   {
-    Set<K> set = new TreeSet<K>();
+    // This is obviously stupid, but since the .hashCode of TupleExpr is broken (and it is not Comparable) we could not use a HashSet either.
+    Set<K> set = new TreeSet<K>(new Comparator<K>() {
+      @Override
+      public int compare(K k1, K k2)
+      {
+        return k1.toString().compareTo(k2.toString());
+      }
+    });
     for (AccessFrequencyMapEntry<K, V> entry : list) {
       set.add(entry.getKey());
     }

--- a/src/main/java/general/Main.java
+++ b/src/main/java/general/Main.java
@@ -24,6 +24,8 @@ import com.univocity.parsers.common.ParsingContext;
 import com.univocity.parsers.common.processor.ObjectRowProcessor;
 import com.univocity.parsers.tsv.TsvParser;
 import com.univocity.parsers.tsv.TsvParserSettings;
+
+import accessfrequencymap.AccessFrequencyMap;
 import input.InputHandlerParquet;
 import input.InputHandlerTSV;
 import logging.LoggingHandler;
@@ -68,7 +70,7 @@ public final class Main
   /**
    * Saves the encountered queryTypes.
    */
-  public static final Map<TupleExpr, String> queryTypes = Collections.synchronizedMap(new HashMap<TupleExpr, String>());
+  public static final Map<TupleExpr, String> queryTypes = Collections.synchronizedMap(new AccessFrequencyMap<TupleExpr, String>());
   /**
    * Saves the mapping of query type and user agent to tool name and version.
    */


### PR DESCRIPTION
FIX: Build a comparator for AccessFrequencyMap.keySet() (since not all
entries must be comparable)
Replaced HashMap for queryTypes with AccessFrequencyMap